### PR TITLE
Changed production environment workspace name

### DIFF
--- a/{{ cookiecutter.project_name }}/README.md
+++ b/{{ cookiecutter.project_name }}/README.md
@@ -48,7 +48,7 @@ terraform apply -auto-approve
 ```
 ## add production environment
 ```
-terraform workspace new test
+terraform workspace new production
 terraform apply -auto-approve
 ```
 


### PR DESCRIPTION
The "add production environment" command referenced the test environment workspace. Fixed it by renaming the workspace to production (which matches the expected branch name).